### PR TITLE
Remove 'branches' key - build doesn't show errors

### DIFF
--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -6,7 +6,6 @@ site:
 content:
   sources: 
   - url: .
-    branches: [main]
 ui: 
   bundle:
     url: https://github.com/rancher/product-docs-ui/blob/main/build/ui-bundle.zip?raw=true


### PR DESCRIPTION
e.g. ko and zh nav.adoc files have invalid refs that aren't listed during build.