### PR TITLE
Add springio/antora-xref-extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@antora/lunr-extension": "^1.0.0-alpha.8",
         "@asciidoctor/tabs": "^1.0.0-beta.6",
+        "@springio/antora-xref-extension": "^1.0.0-alpha.4",
         "nodejieba": "^3.4.2"
       },
       "devDependencies": {
@@ -377,6 +378,14 @@
       "resolved": "https://registry.npmjs.org/@sntke/antora-mermaid-extension/-/antora-mermaid-extension-0.0.6.tgz",
       "integrity": "sha512-c4L+JsJYQYq/R73h5yRdBBR1jVkVdhIm6yhRy1Y009IpvvYAQor3TIxwaFXnPNR2NyfSlXUpXHelkEHddmJMOw==",
       "dev": true
+    },
+    "node_modules/@springio/antora-xref-extension": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@springio/antora-xref-extension/-/antora-xref-extension-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-ybIqQaNgK2pjAkOAd/A+IXK5AmxDZcKfpsp528UXIG2N3L4KFwvwljhANHktS0HHiN5QMZp0PuD0WZsClpenhQ==",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@antora/lunr-extension": "^1.0.0-alpha.8",
     "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@springio/antora-xref-extension": "^1.0.0-alpha.4",
     "nodejieba": "^3.4.2"
   }
 }

--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -21,6 +21,7 @@ asciidoc:
   - '@asciidoctor/tabs'
 antora:
   extensions:
+  - require: '@springio/antora-xref-extension'
   - require: '@antora/lunr-extension'
     languages: [en, ja, zh] # ko not supported by extension
   - require: '@sntke/antora-mermaid-extension' # <1>


### PR DESCRIPTION
Adds the [spring-io/antora-xref-extension](https://github.com/spring-io/antora-xref-extension) extension as Antora's built-in validation doesn't support xrefs with fragments (i.e. linking to the header of another file). 

This depends on #88 as this type of broken link is considered `ERROR` level by the extension, which means CI for this PR won't pass.
