### PR TITLE
Register springio/antora-xref-extension in remote playbook

### DIFF
--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -21,10 +21,10 @@ asciidoc:
   - '@asciidoctor/tabs'
 antora:
   extensions:
-  - require: '@springio/antora-xref-extension'
   - require: '@antora/lunr-extension'
     languages: [en, ja, zh] # ko not supported by extension
   - require: '@sntke/antora-mermaid-extension' # <1>
     mermaid_library_url: https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs # <2>
     script_stem: header-scripts # <3>
     mermaid_initialize_options: # <4>
+  - require: '@springio/antora-xref-extension'

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -29,3 +29,4 @@ antora:
     mermaid_library_url: https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs # <2>
     script_stem: header-scripts # <3>
     mermaid_initialize_options: # <4>
+  - require: '@springio/antora-xref-extension'


### PR DESCRIPTION
The remote playbook was missed as part of #87.

Also rearranged the `antora.extensions` so that they're sorted alphabetically.