### PR TITLE
Sync PR #380 (Hide old cis and remove 1.20 information) from Community docs

### DIFF
--- a/versions/latest/modules/en/nav.adoc
+++ b/versions/latest/modules/en/nav.adoc
@@ -23,7 +23,6 @@
 ** xref:security/hardening-guide.adoc[]
 ** xref:security/self-assessment-1.8.adoc[]
 ** xref:security/self-assessment-1.7.adoc[]
-** xref:security/self-assessment-1.24.adoc[]
 * xref:cli/cli.adoc[]
 ** xref:cli/server.adoc[server]
 ** xref:cli/agent.adoc[agent]

--- a/versions/latest/modules/en/pages/security/hardening-guide.adoc
+++ b/versions/latest/modules/en/pages/security/hardening-guide.adoc
@@ -414,12 +414,8 @@ spec:
   - Ingress
 ----
 
-The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Traefik v1 as packaged in K3s version 1.20 and below uses different labels than Traefik v2. Ensure that you only use the sample yaml below that is associated with the version of Traefik present on your cluster.
+The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Ensure that you use the sample yaml below:
 
-[tabs]
-======
-v1.21 and Newer::
-+
 [,yaml]
 ----
 apiVersion: networking.k8s.io/v1
@@ -465,56 +461,6 @@ spec:
   - Ingress
 ---
 ----
-
-
-v1.20 and Older::
-+
-[,yaml]
-----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-metrics-server
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      k8s-app: metrics-server
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-svclbtraefik-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      svccontroller.k3s.cattle.io/svcname: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-traefik-v120-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      app: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-----
-======
 
 [IMPORTANT]
 ====

--- a/versions/latest/modules/ja/nav.adoc
+++ b/versions/latest/modules/ja/nav.adoc
@@ -23,7 +23,6 @@
 ** xref:security/hardening-guide.adoc[]
 ** xref:security/self-assessment-1.8.adoc[]
 ** xref:security/self-assessment-1.7.adoc[]
-** xref:security/self-assessment-1.24.adoc[]
 * xref:cli/cli.adoc[]
 ** xref:cli/server.adoc[server]
 ** xref:cli/agent.adoc[]

--- a/versions/latest/modules/ja/pages/security/hardening-guide.adoc
+++ b/versions/latest/modules/ja/pages/security/hardening-guide.adoc
@@ -418,13 +418,8 @@ spec:
   - Ingress
 ----
 
-メトリクスサーバーおよび Traefik Ingress コントローラーは、アクセスを許可するネットワークポリシーが作成されない限り、デフォルトでブロックされます。K3s バージョン 1.20 およびそれ以前にパッケージ化された Traefik v1 は、Traefik v2 とは異なるラベルを使用します。クラスターに存在する Traefik のバージョンに関連するサンプル YAML のみを使用するようにしてください。
+メトリクスサーバーおよび Traefik Ingress コントローラーは、アクセスを許可するネットワークポリシーが作成されない限り、デフォルトでブロックされます。Ensure that you use the sample yaml below:
 
-[tabs]
-======
-v1.21 and Newer::
-+
---
 [,yaml]
 ----
 apiVersion: networking.k8s.io/v1
@@ -470,58 +465,6 @@ spec:
   - Ingress
 ---
 ----
---
-
-v1.20 and Older::
-+
---
-[,yaml]
-----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-metrics-server
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      k8s-app: metrics-server
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-svclbtraefik-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      svccontroller.k3s.cattle.io/svcname: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-traefik-v120-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      app: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-----
---
-======
 
 [IMPORTANT]
 ====

--- a/versions/latest/modules/ko/nav.adoc
+++ b/versions/latest/modules/ko/nav.adoc
@@ -23,7 +23,6 @@
 ** xref:security/hardening-guide.adoc[]
 ** xref:security/self-assessment-1.8.adoc[]
 ** xref:security/self-assessment-1.7.adoc[]
-** xref:security/self-assessment-1.24.adoc[]
 * xref:cli/cli.adoc[]
 ** xref:cli/server.adoc[server]
 ** xref:cli/agent.adoc[agent]

--- a/versions/latest/modules/ko/pages/security/hardening-guide.adoc
+++ b/versions/latest/modules/ko/pages/security/hardening-guide.adoc
@@ -414,12 +414,8 @@ spec:
   - Ingress
 ----
 
-The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Traefik v1 as packaged in K3s version 1.20 and below uses different labels than Traefik v2. Ensure that you only use the sample yaml below that is associated with the version of Traefik present on your cluster.
+The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Ensure that you use the sample yaml below:
 
-[tabs]
-======
-v1.21 and Newer::
-+
 [,yaml]
 ----
 apiVersion: networking.k8s.io/v1
@@ -465,56 +461,6 @@ spec:
   - Ingress
 ---
 ----
-
-
-v1.20 and Older::
-+
-[,yaml]
-----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-metrics-server
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      k8s-app: metrics-server
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-svclbtraefik-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      svccontroller.k3s.cattle.io/svcname: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-traefik-v120-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      app: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-----
-======
 
 [IMPORTANT]
 ====

--- a/versions/latest/modules/zh/nav.adoc
+++ b/versions/latest/modules/zh/nav.adoc
@@ -23,7 +23,6 @@
 ** xref:security/hardening-guide.adoc[]
 ** xref:security/self-assessment-1.8.adoc[]
 ** xref:security/self-assessment-1.7.adoc[]
-** xref:security/self-assessment-1.24.adoc[]
 * xref:cli/cli.adoc[]
 ** xref:cli/server.adoc[server]
 ** xref:cli/agent.adoc[agent]

--- a/versions/latest/modules/zh/pages/security/hardening-guide.adoc
+++ b/versions/latest/modules/zh/pages/security/hardening-guide.adoc
@@ -419,12 +419,8 @@ spec:
   - Ingress
 ----
 
-The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Traefik v1 as packaged in K3s version 1.20 and below uses different labels than Traefik v2. Ensure that you only use the sample yaml below that is associated with the version of Traefik present on your cluster.
+The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Ensure that you use the sample yaml below:
 
-[tabs]
-======
-v1.21 and Newer::
-+
 [,yaml]
 ----
 apiVersion: networking.k8s.io/v1
@@ -470,56 +466,6 @@ spec:
   - Ingress
 ---
 ----
-
-
-v1.20 and Older::
-+
-[,yaml]
-----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-metrics-server
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      k8s-app: metrics-server
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-svclbtraefik-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      svccontroller.k3s.cattle.io/svcname: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-all-traefik-v120-ingress
-  namespace: kube-system
-spec:
-  podSelector:
-    matchLabels:
-      app: traefik
-  ingress:
-  - {}
-  policyTypes:
-  - Ingress
----
-----
-======
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Fixes #104 

Relates to:
- https://github.com/k3s-io/docs/pull/380