### PR TITLE
Add script to check for links to Community docs

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -32,8 +32,6 @@ jobs:
               BUILD_STATUS=1
             fi
             echo "BUILD_STATUS=$BUILD_STATUS" >> $GITHUB_ENV
-      - name: Check files for missing nav entries
-        run: bin/files-missing-nav
       - name: Check for build errors
         run: |
           echo ${{ env.BUILD_STATUS }}
@@ -43,3 +41,8 @@ jobs:
             cat local-build.log
             exit 1
           fi
+      - name: Check files for missing nav entries
+        run: bin/files-missing-nav
+      - name: Check for links to Community docs
+        run: bin/community-links
+

--- a/bin/community-links
+++ b/bin/community-links
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+IFS=$'\n'
+DOCS_DIR="docs"
+COMMUNITY_LINKS=(
+    "https://elemental.docs.rancher.com"
+    "https://fleet.rancher.io"
+    "https://docs.harvesterhci.io"
+    "https://docs.k3s.io"
+    "https://docs.kubewarden.io"
+    "https://longhorn.io/docs"
+    "https://open-docs.neuvector.com"
+    "https://ranchermanager.docs.rancher.com"
+    "https://docs.rke2.io"
+    "https://docs.stackstate.com"
+    "https://turtles.docs.rancher.com"
+)
+
+# Naming convention inconsistent. Check for other variation.
+if [ -d versions ]; then
+  DOCS_DIR="versions"
+fi
+
+if test -f tmp/community-links.log; then
+    rm tmp/community-links.log
+elif ! test -d tmp; then
+    mkdir tmp
+fi
+
+grep -rHn "${COMMUNITY_LINKS[*]}" $DOCS_DIR > tmp/community-links.log
+
+if  test -s tmp/community-links.log; then
+    echo "Links to Community docs found in the following. The results have been saved to tmp/community-links.log."
+    cat tmp/community-links.log
+    exit 1
+else
+    echo "No Community docs links found."
+    exit 0
+fi

--- a/bin/files-missing-nav
+++ b/bin/files-missing-nav
@@ -8,7 +8,7 @@ if [ -d versions ]; then
 fi
 
 if test -f tmp/files-missing-nav.log; then
-    truncate -s 0 tmp/files-missing-nav.log
+    rm tmp/files-missing-nav.log
 elif ! test -d tmp; then
     mkdir tmp
 fi
@@ -29,8 +29,10 @@ for dir in $MODULE_LANG_DIRS; do
 done
 
 if test -f tmp/files-missing-nav.log; then
+    echo "The following files are missing from nav.adoc. The results have been saved to tmp/files-missing-nav.log."
     cat tmp/files-missing-nav.log
     exit 1
 else
+    echo "All files are listed in nav.adoc."
     exit 0
 fi


### PR DESCRIPTION
## Description

Add a script that checks for links to our Community docs, which should link to our Product docs instead. The check has been added to the [test-deploy](https://github.com/rancher/k3s-product-docs/blob/main/.github/workflows/test-deploy.yml) workflow and also available to run during local development. 