### PR TITLE
Update nav file references for updated i18n list

### DIFF
--- a/docs/latest/antora.yml
+++ b/docs/latest/antora.yml
@@ -7,7 +7,10 @@ asciidoc:
   attributes:
     longhorn_docs_version: 1.8
 nav:
-- modules/en/nav.adoc
-- modules/ja/nav.adoc
-- modules/ko/nav.adoc
-- modules/zh/nav.adoc
+  - modules/en/nav.adoc
+  - modules/de/nav.adoc
+  - modules/es/nav.adoc
+  - modules/fr/nav.adoc
+  - modules/ja/nav.adoc
+  - modules/pt/nav.adoc
+  - modules/zh/nav.adoc


### PR DESCRIPTION
Currently the nav menu is not rendering when viewing the newly introduced languages.

Note: depends on #228 to fix CI errors.