### PR TITLE
Dependabot: apply update cooldown to all github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,4 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
-      include:
-        - "actions/checkout"
-        - "actions/setup-node"
     


### PR DESCRIPTION
Exclusion should be used instead when needed (e.g. our own actions)