### PR TITLE
[sync k3s-docs] Remove contradictory secrets-encrypt notes

### DIFF
--- a/docs/latest/modules/en/pages/cli/secrets-encrypt.adoc
+++ b/docs/latest/modules/en/pages/cli/secrets-encrypt.adoc
@@ -1,6 +1,6 @@
 = k3s secrets-encrypt
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-29
+:revdate: 2026-07-22
 :page-revdate: {revdate}
 
 K3s supports enabling secrets encryption at rest. For more information, see xref:security/secrets-encryption.adoc[Secrets Encryption].
@@ -222,11 +222,6 @@ Single-Server::
 To rotate secrets encryption keys on a single-server cluster:
 
 . Start the K3s server with the flag `--secrets-encryption`
-+
-[NOTE]
-====
-Starting K3s without encryption and enabling it at a later time is currently _not_ supported.
-====
 
 . Prepare
 +
@@ -278,8 +273,7 @@ To rotate secrets encryption keys on HA setups:
 +
 [NOTE]
 ====
-* Starting K3s without encryption and enabling it at a later time is currently _not_ supported.
-* While not required, it is recommended that you pick one server node from which to run the `secrets-encrypt` commands.
+While not required, it is recommended that you pick one server node from which to run the `secrets-encrypt` commands.
 ====
 . Prepare on S1
 +


### PR DESCRIPTION
Port of the remaining part of k3s-io/docs commit 81e5698d6 ("Add documentation on enabling secrets-encryption on existing clusters (#565)").

The main content of that commit (the "Enable Secrets Encryption on an Existing Cluster" section) was already present in k3s-product-docs. However, the older notes stating "Starting K3s without encryption and enabling it at a later time is currently not supported" were still present and now directly contradict that section. This removes those notes:

- Single-server legacy rotation: removed the standalone NOTE block.
- HA legacy rotation: removed only the contradictory bullet, keeping the "pick one server node" recommendation.

English page updated; revdate bumped.

Source commit: https://github.com/k3s-io/docs/commit/81e5698d6
Source PR: https://github.com/k3s-io/docs/pull/565