### PR TITLE
[sync k3s-docs] Remove outdated control plane CPU/memory table

### DIFF
--- a/docs/latest/modules/en/pages/installation/requirements.adoc
+++ b/docs/latest/modules/en/pages/installation/requirements.adoc
@@ -1,5 +1,5 @@
 = Requirements
-:revdate: 2026-03-31
+:revdate: 2026-07-22
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 
@@ -375,39 +375,7 @@ Hardware requirements are based on the size of your K3s cluster. For production 
 * PostgreSQL
 * etcd
 
-=== CPU and Memory
-
-The following are the minimum CPU and memory requirements for nodes in a high-availability K3s server:
-
-[cols="^,^,^,^"]
-|===
-| Deployment Size | Nodes | vCPUs | RAM
-
-| Small
-| Up to 10
-| 2
-| 4 GB
-
-| Medium
-| Up to 100
-| 4
-| 8 GB
-
-| Large
-| Up to 250
-| 8
-| 16 GB
-
-| X-Large
-| Up to 500
-| 16
-| 32 GB
-
-| XX-Large
-| 500+
-| 32
-| 64 GB
-|===
+For control-plane node CPU and memory sizing relative to the number of agents, see the <<_server_sizing_guide,Server Sizing Guide>> above.
 
 === Disks
 


### PR DESCRIPTION
Port of k3s-io/docs commit a5ea0f0e4 ("remove outdated control plane CPU/memory table (#572)").

The static Small/Medium/Large CPU and memory table in the "Large Clusters" section is outdated. Removed it and replaced it with a pointer to the Server Sizing Guide section already on this page, which gives control-plane sizing relative to the number of agents.

English page updated; revdate bumped.

Source commit: https://github.com/k3s-io/docs/commit/a5ea0f0e4505b08ab9b6f3fa13e5cdeed59b8d1e
Source PR: https://github.com/k3s-io/docs/pull/572