### PR TITLE
[sync k3s-docs] Fix duplicated "the the" typo in etcd-snapshot page

### DIFF
--- a/docs/latest/modules/en/pages/cli/etcd-snapshot.adoc
+++ b/docs/latest/modules/en/pages/cli/etcd-snapshot.adoc
@@ -1,5 +1,5 @@
 = k3s etcd-snapshot
-:revdate: 2026-04-01
+:revdate: 2026-07-22
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 
@@ -228,7 +228,7 @@ S3 configuration must be passed via the CLI when restoring a snapshot stored on 
 
 [NOTE]
 ====
-Pass only the the `--etcd-s3` and `--etcd-s3-config-secret` flags to enable the Secret.
+Pass only the `--etcd-s3` and `--etcd-s3-config-secret` flags to enable the Secret.
 If any other S3 configuration flags are set, the Secret will be ignored.
 ====
 


### PR DESCRIPTION
Port of the remaining part of k3s-io/docs commit 4a7beb338 ("Fix typos").

Two of the three "the the" fixes from that commit were already present in k3s-product-docs (add-ons/helm and installation/private-registry); the etcd-snapshot one was missed. This corrects "Pass only the the `--etcd-s3`..." to "Pass only the `--etcd-s3`...".

English page updated; revdate bumped.

Source commit: https://github.com/k3s-io/docs/commit/4a7beb338