### PR TITLE
[sync k3s-docs] Update release notes (v1.33.13, v1.34.9, v1.35.6, v1.…

### DIFF
--- a/docs/latest/modules/en/pages/release-notes/v1.33.X.adoc
+++ b/docs/latest/modules/en/pages/release-notes/v1.33.X.adoc
@@ -1,5 +1,5 @@
 = v1.33.X
-:revdate: 2026-05-25
+:revdate: 2026-07-22
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 :page-role: -toc
@@ -12,6 +12,21 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Kine | SQLite | Etcd | Containerd | Runc | Flannel | Metrics-server | Traefik | CoreDNS | Helm-controller | Local-path-provisioner
+
+| xref:#_release_v1_33_13k3s1[v1.33.13+k3s1]
+| Jun 24 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13313[v1.33.13]
+| https://github.com/k3s-io/kine/releases/tag/v0.16.1[v0.16.1]
+| https://sqlite.org/releaselog/3_53_0.html[3.53.0]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1.33[v2.2.5-k3s1.33]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.4[v0.28.4]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36[v0.0.36]
 
 | xref:#_release_v1_33_12k3s1[v1.33.12+k3s1]
 | May 20 2026
@@ -223,6 +238,28 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 | https://github.com/k3s-io/helm-controller/releases/tag/v0.16.10[v0.16.10]
 | https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31[v0.0.31]
 |===
+
+== Release https://github.com/k3s-io/k3s/releases/tag/v1.33.13+k3s1[v1.33.13+k3s1]
+// v1.33.13+k3s1
+
+[WARNING]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details.
+====
+
+This release updates Kubernetes to v1.33.13, and fixes a number of issues.
+
+For more details on what’s new, see the https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v13312[Kubernetes release notes].
+
+=== Changes since v1.33.12+k3s1:
+
+* Backports for 2026-06 https://github.com/k3s-io/k3s/pull/14155[(#14155)]
+* Bump v3.7.4 Traefik https://github.com/k3s-io/k3s/pull/14196[(#14196)]
+* More backports for 2026-06 https://github.com/k3s-io/k3s/pull/14218[(#14218)]
+* Testing Backports 2026-06 https://github.com/k3s-io/k3s/pull/14217[(#14217)]
+* Bump klipper-helm for CVE reasons https://github.com/k3s-io/k3s/pull/14238[(#14238)]
+* Update to v1.33.13-k3s1 and Go 1.25.11 https://github.com/k3s-io/k3s/pull/14227[(#14227)]
+* Bump containerd to v2.2.5-k3s1.33 https://github.com/k3s-io/k3s/pull/14256[(#14256)]
 
 == Release https://github.com/k3s-io/k3s/releases/tag/v1.33.12+k3s1[v1.33.12+k3s1]
 // v1.33.12+k3s1

--- a/docs/latest/modules/en/pages/release-notes/v1.34.X.adoc
+++ b/docs/latest/modules/en/pages/release-notes/v1.34.X.adoc
@@ -1,5 +1,5 @@
 = v1.34.X
-:revdate: 2026-05-25
+:revdate: 2026-07-22
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 :page-role: -toc
@@ -12,6 +12,21 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Kine | SQLite | Etcd | Containerd | Runc | Flannel | Metrics-server | Traefik | CoreDNS | Helm-controller | Local-path-provisioner
+
+| xref:#_release_v1_34_9k3s1[v1.34.9+k3s1]
+| Jun 24 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1349[v1.34.9]
+| https://github.com/k3s-io/kine/releases/tag/v0.16.1[v0.16.1]
+| https://sqlite.org/releaselog/3_53_0.html[3.53.0]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s2[v2.2.5-k3s2]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.4[v0.28.4]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36[v0.0.36]
 
 | xref:#_release_v1_34_8k3s1[v1.34.8+k3s1]
 | May 20 2026
@@ -148,6 +163,31 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 | https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13[v0.16.13]
 | https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.32[v0.0.32]
 |===
+
+== Release https://github.com/k3s-io/k3s/releases/tag/v1.34.9+k3s1[v1.34.9+k3s1]
+// v1.34.9+k3s1
+
+[WARNING]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details.
+====
+
+This release updates Kubernetes to v1.34.9, and fixes a number of issues.
+
+For more details on what’s new, see the https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#changelog-since-v1348[Kubernetes release notes].
+
+=== Changes since v1.34.8+k3s1:
+
+* Backport GitHub Action SHA pin updates from main https://github.com/k3s-io/k3s/pull/14125[(#14125)]
+* Backports for 2026-06 https://github.com/k3s-io/k3s/pull/14154[(#14154)]
+* Bump v3.7.4 Traefik https://github.com/k3s-io/k3s/pull/14195[(#14195)]
+* More backports for 2026-06 https://github.com/k3s-io/k3s/pull/14216[(#14216)]
+* Testing Backports 2026-06 https://github.com/k3s-io/k3s/pull/14215[(#14215)]
+* Bump klipper-helm for CVE reasons https://github.com/k3s-io/k3s/pull/14239[(#14239)]
+* Bump containerd with the fix for []byte https://github.com/k3s-io/k3s/pull/14242[(#14242)]
+* Update to v1.34.9-k3s1 and Go 1.25.11 https://github.com/k3s-io/k3s/pull/14228[(#14228)]
+* Bump containerd to v2.2.5-k3s1 https://github.com/k3s-io/k3s/pull/14255[(#14255)]
+* Bump cri-api and containerd for upstream env string fix https://github.com/k3s-io/k3s/pull/14279[(#14279)]
 
 == Release https://github.com/k3s-io/k3s/releases/tag/v1.34.8+k3s1[v1.34.8+k3s1]
 // v1.34.8+k3s1

--- a/docs/latest/modules/en/pages/release-notes/v1.35.X.adoc
+++ b/docs/latest/modules/en/pages/release-notes/v1.35.X.adoc
@@ -1,6 +1,6 @@
 = v1.35.X
 :page-languages: [en, ja, ko, zh]
-:revdate: 2026-05-25
+:revdate: 2026-07-22
 :page-revdate: {revdate}
 :page-role: -toc
 
@@ -12,6 +12,21 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Kine | SQLite | Etcd | Containerd | Runc | Flannel | Metrics-server | Traefik | CoreDNS | Helm-controller | Local-path-provisioner
+
+| xref:#_release_v1_35_6k3s1[v1.35.6+k3s1]
+| Jun 24 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#v1356[v1.35.6]
+| https://github.com/k3s-io/kine/releases/tag/v0.16.1[v0.16.1]
+| https://sqlite.org/releaselog/3_53_0.html[3.53.0]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s2[v2.2.5-k3s2]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.4[v0.28.4]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36[v0.0.36]
 
 | xref:#_release_v1_35_5k3s1[v1.35.5+k3s1]
 | May 20 2026
@@ -118,6 +133,31 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 | https://github.com/k3s-io/helm-controller/releases/tag/v0.16.17[v0.16.17]
 | https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.32[v0.0.32]
 |===
+
+== Release https://github.com/k3s-io/k3s/releases/tag/v1.35.6+k3s1[v1.35.6+k3s1]
+// v1.35.6+k3s1
+
+[WARNING]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details.
+====
+
+This release updates Kubernetes to v1.35.6, and fixes a number of issues.
+
+For more details on what’s new, see the https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#changelog-since-v1355[Kubernetes release notes].
+
+=== Changes since v1.35.5+k3s1:
+
+* Backport GitHub Action SHA pin updates from main https://github.com/k3s-io/k3s/pull/14126[(#14126)]
+* Backports for 2026-06 https://github.com/k3s-io/k3s/pull/14152[(#14152)]
+* Bump v3.7.4 Traefik https://github.com/k3s-io/k3s/pull/14194[(#14194)]
+* More backports for 2026-06 https://github.com/k3s-io/k3s/pull/14212[(#14212)]
+* Testing Backports 2026-06 https://github.com/k3s-io/k3s/pull/14214[(#14214)]
+* Bump klipper-helm for CVE reasons (#14235) https://github.com/k3s-io/k3s/pull/14237[(#14237)]
+* Bump containerd to fix []byte envvar value https://github.com/k3s-io/k3s/pull/14241[(#14241)]
+* Update to v1.35.6-k3s1 and Go 1.25.11 https://github.com/k3s-io/k3s/pull/14229[(#14229)]
+* Bump containerd for 1.35 https://github.com/k3s-io/k3s/pull/14251[(#14251)]
+* Bump cri-api and containerd for upstream env string fix https://github.com/k3s-io/k3s/pull/14278[(#14278)]
 
 == Release https://github.com/k3s-io/k3s/releases/tag/v1.35.5+k3s1[v1.35.5+k3s1]
 // v1.35.5+k3s1

--- a/docs/latest/modules/en/pages/release-notes/v1.36.X.adoc
+++ b/docs/latest/modules/en/pages/release-notes/v1.36.X.adoc
@@ -1,6 +1,6 @@
 = v1.36.X
 :page-languages: [en, ja, ko, zh]
-:revdate: 2026-05-25
+:revdate: 2026-07-22
 :page-revdate: {revdate}
 :page-role: -toc
 
@@ -12,6 +12,21 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Kine | SQLite | Etcd | Containerd | Runc | Flannel | Metrics-server | Traefik | CoreDNS | Helm-controller | Local-path-provisioner
+
+| xref:#_release_v1_36_2k3s1[v1.36.2+k3s1]
+| Jun 24 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1362[v1.36.2]
+| https://github.com/k3s-io/kine/releases/tag/v0.16.1[v0.16.1]
+| https://sqlite.org/releaselog/3_53_0.html[3.53.0]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.3.2-k3s2[v2.3.2-k3s2]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.4[v0.28.4]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36[v0.0.36]
 
 | xref:#_release_v1_36_1k3s1[v1.36.1+k3s1]
 | May 20 2026
@@ -44,6 +59,31 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 | https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
 | https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.35[v0.0.35]
 |===
+
+== Release https://github.com/k3s-io/k3s/releases/tag/v1.36.2+k3s1[v1.36.2+k3s1]
+// v1.36.2+k3s1
+
+[WARNING]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details.
+====
+
+This release updates Kubernetes to v1.36.2, and fixes a number of issues.
+
+For more details on what’s new, see the https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#changelog-since-v1361[Kubernetes release notes].
+
+=== Changes since v1.36.1+k3s1:
+
+* Backport GitHub Action SHA pin updates from main https://github.com/k3s-io/k3s/pull/14127[(#14127)]
+* Backports for 2026-06 https://github.com/k3s-io/k3s/pull/14151[(#14151)]
+* Bump v3.7.4 Traefik https://github.com/k3s-io/k3s/pull/14193[(#14193)]
+* More backports for 2026-06 https://github.com/k3s-io/k3s/pull/14211[(#14211)]
+* Testing Backports 2026-06 https://github.com/k3s-io/k3s/pull/14213[(#14213)]
+* Bump klipper-helm for CVE reasons (#14235) https://github.com/k3s-io/k3s/pull/14236[(#14236)]
+* Bump containerd with the fix for []byte https://github.com/k3s-io/k3s/pull/14243[(#14243)]
+* Update to v1.36.2-k3s1 and Go 1.26.4 https://github.com/k3s-io/k3s/pull/14230[(#14230)]
+* Bump containerd to v2.3.2-k3s1 https://github.com/k3s-io/k3s/pull/14254[(#14254)]
+* Bump cri-api and containerd for upstream env string fix https://github.com/k3s-io/k3s/pull/14277[(#14277)]
 
 == Release https://github.com/k3s-io/k3s/releases/tag/v1.36.1+k3s1[v1.36.1+k3s1]
 // v1.36.1+k3s1


### PR DESCRIPTION
…36.2)

Catch-up sync of the auto-generated release notes from k3s-io/docs, which had fallen one patch release behind on every maintained minor. Adds the latest release for each:

- v1.36.X: add v1.36.2+k3s1
- v1.35.X: add v1.35.6+k3s1
- v1.34.X: add v1.34.9+k3s1
- v1.33.X: add v1.33.13+k3s1

For each, the summary table gets a new top row and a new "== Release" section with the full "Changes since" changelog, converted from upstream Markdown to AsciiDoc (links, admonitions). No columns were added; the existing table structure is preserved. English pages only; revdate bumped.

These correspond to the periodic "update release-notes/k3s-*.md" commits in k3s-io/docs (e.g. 6d7081891, 219134788, c3766448f).

Source: https://github.com/k3s-io/docs/tree/main/docs/release-notes