### PR TITLE
[sync k3s-docs] Update Rancher docs link in automated upgrades page

### DIFF
--- a/docs/latest/modules/en/pages/upgrades/automated.adoc
+++ b/docs/latest/modules/en/pages/upgrades/automated.adoc
@@ -16,7 +16,7 @@ The System Upgrade controller schedules upgrades by monitoring plans and selecti
 If the K3s cluster is managed by Rancher, you should use the Rancher UI to manage upgrades.
 
 * If the K3s cluster is imported (registered) into Rancher, Rancher manages the system-upgrade-controller deployment and plans by default. Do not follow the steps on this page unless you have disabled version management in Rancher.
-  See https://rancher.github.io/product-docs-playbook/rancher-manager/latest/en/cluster-deployment/register-existing-clusters.html#_additional_features_for_registered_rke2_and_k3s_clusters[Additional Features for Registered RKE2 and K3s Clusters] for more information.
+  See https://documentation.suse.com/cloudnative/rancher-manager/latest/en/cluster-deployment/register-existing-clusters.html#_additional_features_for_registered_rke2_and_k3s_clusters[Additional Features for Registered RKE2 and K3s Clusters] for more information.
 * If the K3s cluster is provisioned by Rancher, Rancher uses the system agent to manage version upgrades. Do not follow the steps on this page.
 * If the K3s cluster is *not* managed by Rancher, you may follow the steps below.
 ====

--- a/docs/latest/modules/en/pages/upgrades/automated.adoc
+++ b/docs/latest/modules/en/pages/upgrades/automated.adoc
@@ -1,5 +1,5 @@
 = Automated Upgrades
-:revdate: 2026-03-31
+:revdate: 2026-07-22
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 
@@ -16,7 +16,7 @@ The System Upgrade controller schedules upgrades by monitoring plans and selecti
 If the K3s cluster is managed by Rancher, you should use the Rancher UI to manage upgrades.
 
 * If the K3s cluster is imported (registered) into Rancher, Rancher manages the system-upgrade-controller deployment and plans by default. Do not follow the steps on this page unless you have disabled version management in Rancher.
-  See https://rancher.github.io/product-docs-playbook/rancher-manager/latest/en/cluster-deployment/register-existing-clusters.html#_configuring_version_management_for_suse_rancher_prime_rke2_and_suse_rancher_prime_k3s_clusters[Configuring Version Management for RKE2 and K3s Clusters] for more information.
+  See https://rancher.github.io/product-docs-playbook/rancher-manager/latest/en/cluster-deployment/register-existing-clusters.html#_additional_features_for_registered_rke2_and_k3s_clusters[Additional Features for Registered RKE2 and K3s Clusters] for more information.
 * If the K3s cluster is provisioned by Rancher, Rancher uses the system agent to manage version upgrades. Do not follow the steps on this page.
 * If the K3s cluster is *not* managed by Rancher, you may follow the steps below.
 ====


### PR DESCRIPTION
Port of k3s-io/docs commit 12d9c36a6 ("Update Rancher docs link").

The Rancher registered-clusters section was restructured; the link on the automated upgrades page now points to the "Additional Features for Registered RKE2 and K3s Clusters" section. In k3s-product-docs the link targets the SUSE Rancher Prime product-docs-playbook (Prime-specific), whose previous anchor (_configuring_version_management_for_suse_rancher_prime_rke2_and_suse_rancher_prime_k3s_clusters) no longer exists on the page. This updates the anchor to _additional_features_for_registered_rke2_and_k3s_clusters and the link text accordingly, fixing the broken link while keeping the Prime playbook URL.

Bumped revdate.

Source commit: https://github.com/k3s-io/docs/commit/12d9c36a6b08810a3a37615d62fdc7e8111ae030