### PR TITLE
[k3s-docs sync] Sync keepalived link

### DIFF
--- a/docs/latest/modules/en/pages/datastore/cluster-loadbalancer.adoc
+++ b/docs/latest/modules/en/pages/datastore/cluster-loadbalancer.adoc
@@ -1,5 +1,5 @@
 = Cluster Load Balancer
-:revdate: 2026-03-31
+:revdate: 2026-07-22
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 
@@ -54,7 +54,7 @@ HAProxy::
 --
 http://www.haproxy.org/[HAProxy] is an open source option that provides a TCP load balancer. It also supports HA for the load balancer itself, ensuring redundancy at all levels. See http://docs.haproxy.org/2.8/intro.html[HAProxy Documentation] for more info.
 
-Additionally, we will use KeepAlived to generate a virtual IP (VIP) that will be used to access the cluster. See https://www.keepalived.org/manpage.html[KeepAlived Documentation] for more info.
+Additionally, we will use KeepAlived to generate a virtual IP (VIP) that will be used to access the cluster. See https://www.keepalived.org/documentation/[KeepAlived Documentation] for more info.
 
 . Install HAProxy and KeepAlived:
 +


### PR DESCRIPTION
Port of the "Update keepalived docs link" change from k3s-io/docs PR #578. That PR was squash-merged as commit 6d7081891 with the title "Update Release Notes July 2026", but it also bundled this documentation fix.

The KeepAlived documentation link on the cluster load balancer page moved from https://www.keepalived.org/manpage.html to
https://www.keepalived.org/documentation/. This updates the link accordingly and bumps revdate.

PR #578 also modified .github/workflows/release-notes.yml (adding dos2unix line-ending normalization). That workflow does not exist in k3s-product-docs, so that change is not applicable and was not ported.

Source PR: https://github.com/k3s-io/docs/pull/578
Source commit: https://github.com/k3s-io/docs/commit/6d708189140b5d13849bab15ef4405e955b0685f