### PR TITLE
[sync k3s-docs] Drop EOL Version Gates

### DIFF
--- a/docs/latest/modules/en/pages/cli/etcd-snapshot.adoc
+++ b/docs/latest/modules/en/pages/cli/etcd-snapshot.adoc
@@ -1,5 +1,5 @@
 = k3s etcd-snapshot
-:revdate: 2026-07-22
+:revdate: 2026-07-24
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 
@@ -175,6 +175,11 @@ K3s supports replicating etcd snapshots to and restoring etcd snapshots from S3-
 | Name of secret in the kube-system namespace used to configure S3, if etcd-s3 is enabled and no other etcd-s3 options are set
 |===
 
+[NOTE]
+====
+`--etcd-snapshot-retention` sets `--etcd-s3-retention`, if it is not explicitly set in the config.
+====
+
 For example, this is how the creation and deletion of on-demand etcd snapshots in S3 would work:
 
 [,shell-session]
@@ -195,28 +200,7 @@ $ k3s etcd-snapshot --s3 --s3-bucket=test-bucket --s3-access-key=test --s3-secre
 Name                              Location                                                                          Size    Created
 ----
 
-=== S3 Retention
-
-[NOTE]
-.Version Gate
-====
-Starting in versions v1.34.0+k3s1, v1.33.4+k3s1, v1.32.8+k3s1, v1.31.12+k3s1, K3s includes a new flag for S3 retention. It has the same default value as the local snapshot retention.
-====
-
-|===
-| Flag | Description
-
-| `--etcd-s3-retention`
-| Number of snapshots in S3 to retain. (Default: `5`)
-|===
-
 === S3 Configuration Secret Support
-
-[NOTE]
-.Version Gate
-====
-S3 Configuration Secret support is available as of the August 2024 releases: v1.30.4+k3s1, v1.29.8+k3s1, v1.28.13+k3s1.
-====
 
 K3s supports reading etcd S3 snapshot configuration from a Kubernetes Secret.
 This may be preferred to hardcoding credentials in K3s CLI flags or config files for security reasons, or if credentials need to be rotated without restarting K3s.

--- a/docs/latest/modules/en/pages/cli/secrets-encrypt.adoc
+++ b/docs/latest/modules/en/pages/cli/secrets-encrypt.adoc
@@ -1,6 +1,6 @@
 = k3s secrets-encrypt
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-22
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 K3s supports enabling secrets encryption at rest. For more information, see xref:security/secrets-encryption.adoc[Secrets Encryption].
@@ -21,12 +21,6 @@ Failure to follow proper procedure for rotating encryption keys can leave your c
 
 [#_encryption_key_rotation]
 === Encryption Key Rotation
-
-[IMPORTANT]
-.Version Gate
-====
-Available as of the September 2024 releases: v1.30.5+k3s1, v1.31.1+k3s1.
-====
 
 [tabs,sync-group-id=se]
 ======

--- a/docs/latest/modules/en/pages/installation/private-registry.adoc
+++ b/docs/latest/modules/en/pages/installation/private-registry.adoc
@@ -1,6 +1,6 @@
 = Private Registry Configuration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-12-30
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.
@@ -26,13 +26,6 @@ For example, when pulling `registry.example.com:5000/rancher/mirrored-pause:3.6`
 
 In order to be recognized as a registry, the first component of the image name must contain at least one period or colon.
 For historical reasons, images without a registry specified in their name are implicitly identified as being from `docker.io`.
-
-[IMPORTANT]
-.Version Gate
-====
-The `--disable-default-registry-endpoint` option is available as of January 2024 releases: v1.26.13+k3s1, v1.27.10+k3s1, v1.28.6+k3s1, v1.29.1+k3s1
-====
-
 
 Nodes may be started with the `--disable-default-registry-endpoint` option.
 When this is set, containerd will not fall back to the default registry endpoint, and will only pull from configured mirror endpoints,
@@ -115,13 +108,6 @@ mirrors:
       "^rancher/(.*)": "mirrorproject/rancher-images/$1"
 ----
 
-[NOTE]
-.Version Gate
-====
-Rewrites are no longer applied to the xref:#_default_endpoint_fallback[Default Endpoint] as of the January 2024 releases: v1.26.13+k3s1, v1.27.10+k3s1, v1.28.6+k3s1, v1.29.1+k3s1.
-Prior to these releases, rewrites were also applied to the default endpoint, which would prevent K3s from pulling from the upstream registry if the image could not be pulled from a mirror endpoint, and the image was not available under the modified name in the upstream.
-====
-
 If you want to apply rewrites when pulling directly from a registry - when it is not being used as a mirror for a different upstream registry - you must provide a mirror endpoint that does not match the default endpoint.
 Mirror endpoints in `registries.yaml` that match the default endpoint are ignored; the default endpoint is always tried last with no rewrites, if fallback has not been disabled.
 
@@ -181,13 +167,6 @@ The `auth` part consists of either username/password or authentication token:
 Below are basic examples of using private registries in different modes:
 
 === Wildcard Support
-
-[IMPORTANT]
-.Version Gate
-====
-Wildcard support is available as of the March 2024 releases: v1.26.15+k3s1, v1.27.12+k3s1, v1.28.8+k3s1, v1.29.3+k3s1
-====
-
 
 The `"*"` wildcard entry can be used in the `mirrors` and `configs` sections to provide default configuration for all registries.
 The default configuration will only be used if there is no specific entry for that registry. Note that the asterisk MUST be quoted.

--- a/docs/latest/modules/en/pages/installation/registry-mirror.adoc
+++ b/docs/latest/modules/en/pages/installation/registry-mirror.adoc
@@ -1,13 +1,7 @@
 = Embedded Registry Mirror
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-01-05
+:revdate: 2026-07-24
 :page-revdate: {revdate}
-
-[IMPORTANT]
-.Version Gate
-====
-The Embedded Registry Mirror is available as an experimental feature as of January 2024 releases: v1.26.13+k3s1, v1.27.10+k3s1, v1.28.6+k3s1, v1.29.1+k3s1 and GA as of December 2024 releases: v1.29.12+k3s1, v1.30.8+k3s1, v1.31.4+k3s1.
-====
 
 K3s embeds https://github.com/XenitAB/spegel[Spegel], a stateless distributed OCI registry mirror that allows peer-to-peer sharing of container images between nodes in a Kubernetes cluster. The distributed registry mirror is disabled by default. For K3s to leverage it, you must enable both the xref:#_enabling_the_distributed_oci_registry_mirror[Distributed OCI Registry Mirror] and the xref:#_enabling_registry_mirroring[Registry mirroring] as explained in the following subsections.
 
@@ -67,13 +61,6 @@ registries are enabled - by listing it in the mirrors section:
 mirrors:
   mirror.example.com:
 ----
-
-[IMPORTANT]
-.Version Gate
-====
-Wildcard support is available as of the March 2024 releases: v1.26.15+k3s1, v1.27.12+k3s1, v1.28.8+k3s1, v1.29.3+k3s1
-====
-
 
 The `"*"` wildcard mirror entry can be used to enable distributed mirroring of all registries. Note that the asterisk MUST be quoted:
 

--- a/docs/latest/modules/en/pages/networking/basic-network-options.adoc
+++ b/docs/latest/modules/en/pages/networking/basic-network-options.adoc
@@ -1,6 +1,6 @@
 = Basic Network Options
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-12-31
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 This page describes K3s network configuration options, including configuration or replacement of Flannel, and configuring IPv6 or dualStack.
@@ -40,25 +40,6 @@ You must ensure that WireGuard kernel modules are available on every node, both 
 | `--flannel-backend=none`
 | Disable Flannel entirely.
 |===
-
-[IMPORTANT]
-.Version Gate
-====
-
-K3s no longer includes strongSwan `swanctl` and `charon` binaries starting with the 2022-12 releases (v1.26.0+k3s1, v1.25.5+k3s1, v1.24.9+k3s1, v1.23.15+k3s1). Please install the correct packages on your node before upgrading to or installing these releases if you want to use the `ipsec` backend.
-====
-
-[#_migrating_from_wireguard_or_ipsec_to_wireguard_native]
-=== Migrating from `wireguard` or `ipsec` to `wireguard-native`
-
-The legacy `wireguard` backend requires installation of the `wg` tool on the host. This backend is not available in K3s v1.26 and higher, in favor of `wireguard-native` backend, which directly interfaces with the kernel.
-
-The legacy `ipsec` backend requires installation of the `swanctl` and `charon` binaries on the host. This backend is not available in K3s v1.27 and higher, in favor of the `wireguard-native` backend.
-
-We recommend that users migrate to the new backend as soon as possible. The migration requires a short period of downtime while nodes come up with the new configuration. You should follow these two steps:
-
-. Update the K3s config on all server nodes. If using config files, the `/etc/rancher/k3s/config.yaml` should include `flannel-backend: wireguard-native` instead of `flannel-backend: wireguard` or `flannel-backend: ipsec`. If you are configuring K3s via CLI flags in the systemd unit, the equivalent flags should be changed.
-. Reboot all nodes, starting with the servers.
 
 === Flannel Agent Options
 
@@ -173,29 +154,6 @@ This mode requires that the servers also run the kubelet, CNI, and kube-proxy, o
 
 == Dual-stack (IPv4 + IPv6) Networking
 
-[IMPORTANT]
-.Version Gate
-====
-
-Experimental support is available as of https://github.com/k3s-io/k3s/releases/tag/v1.21.0%2Bk3s1[v1.21.0+k3s1]. +
-Stable support is available as of https://github.com/k3s-io/k3s/releases/tag/v1.23.7%2Bk3s1[v1.23.7+k3s1].
-====
-
-
-[CAUTION]
-.Known Issue
-====
-
-Before 1.27, Kubernetes https://github.com/kubernetes/kubernetes/issues/111695[Issue #111695] causes the Kubelet to ignore the node IPv6 addresses if you have a dual-stack environment and you are not using the primary network interface for cluster traffic. To avoid this bug, use 1.27 or newer or add the following flag to both K3s servers and agents:
-
-----
---kubelet-arg="node-ip=0.0.0.0" # To proritize IPv4 traffic
-#OR
---kubelet-arg="node-ip=::" # To proritize IPv6 traffic
-----
-====
-
-
 Dual-stack networking must be configured when the cluster is first created. It cannot be enabled on an existing cluster once it has been started as IPv4-only.
 
 To enable dual-stack in K3s, you must provide valid dual-stack `cluster-cidr` and `service-cidr` on all server nodes. This is an example of a valid configuration:
@@ -218,13 +176,6 @@ When defining cluster-cidr and service-cidr with IPv6 as the primary family, the
 ====
 
 == Single-stack IPv6 Networking
-
-[IMPORTANT]
-.Version Gate
-====
-Available as of https://github.com/k3s-io/k3s/releases/tag/v1.22.9%2Bk3s1[v1.22.9+k3s1]
-====
-
 
 [CAUTION]
 .Known Issue

--- a/docs/latest/modules/en/pages/networking/multus-ipams.adoc
+++ b/docs/latest/modules/en/pages/networking/multus-ipams.adoc
@@ -1,6 +1,6 @@
 = Multus and IPAM plugins
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 https://github.com/k8snetworkplumbingwg/multus-cni[Multus CNI] is a CNI plugin that enables attaching multiple network interfaces to pods. Multus does not replace CNI plugins, instead it acts as a CNI plugin multiplexer. Multus is useful in certain use cases, especially when pods are network intensive and require extra network interfaces that support dataplane acceleration techniques such as SR-IOV.
@@ -8,12 +8,6 @@ https://github.com/k8snetworkplumbingwg/multus-cni[Multus CNI] is a CNI plugin t
 For more information about Multus, refer to the https://github.com/k8snetworkplumbingwg/multus-cni/tree/master/docs[multus-cni] documentation.
 
 Multus can not be deployed standalone. It always requires at least one conventional CNI plugin that fulfills the Kubernetes cluster network requirements. That CNI plugin becomes the default for Multus, and will be used to provide the primary interface for all pods. When deploying K3s with default options, that CNI plugin is Flannel.
-
-[NOTE]
-.Version Gate
-====
-K3s uses a fixed CNI binary path as of the October 2024 releases: v1.28.15+k3s1, v1.29.10+k3s1, v1.30.6+k3s1, v1.31.2+k3s1.
-====
 
 K3s looks at `$DATA_DIR/data/cni` for CNI plugin binaries. By default this is `/var/lib/rancher/k3s/data/cni`. Additional CNI plugins should be installed to this location.
 

--- a/docs/latest/modules/en/pages/reference/env-variables.adoc
+++ b/docs/latest/modules/en/pages/reference/env-variables.adoc
@@ -1,6 +1,6 @@
 = Environment Variables
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2024-12-05
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 As mentioned in the xref:quick-start.adoc[Quick-Start Guide], you can use the installation script available at https://get.k3s.io to install K3s as a service on systemd and openrc based systems.
@@ -75,12 +75,6 @@ Environment variables which begin with `K3S_` will be preserved for the systemd 
 Setting `K3S_URL` without explicitly setting an exec command will default the command to "agent".
 
 When running the agent, `K3S_TOKEN` must also be set.
-
-[NOTE]
-.Version Gate
-====
-Available as of October 2024 releases: v1.28.15+k3s1, v1.29.10+k3s1, v1.30.6+k3s1, v1.31.2+k3s1.
-====
 
 K3s will now use `PATH` to find alternative container runtimes, in addition to checking the default paths used by the container runtime packages. In order to use this feature, you must modify the K3s service's PATH environment variable to add the directories containing the container runtime binaries.
 

--- a/docs/latest/modules/en/pages/release-notes-old/v1.27.X.adoc
+++ b/docs/latest/modules/en/pages/release-notes-old/v1.27.X.adoc
@@ -920,7 +920,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
  ** `--flannel-backed=wireguard` has been completely replaced with `--flannel-backend=wireguard-native`
  ** The `k3s etcd-snapshot` command will now print a help message, to save a snapshot use: `k3s etcd-snapshot save`
  ** The following flags will now cause fatal errors (with full removal coming in v1.28.0):
-  *** `--flannel-backed=ipsec`: replaced with `--flannel-backend=wireguard-native` xref:networking/basic-network-options.adoc#_migrating_from_wireguard_or_ipsec_to_wireguard_native[see docs for more info.]
+  *** `--flannel-backed=ipsec`: replaced with `--flannel-backend=wireguard-native`
   *** Supplying multiple `--flannel-backend` values is no longer valid. Use `--flannel-conf` instead.
 * Changed command -v redirection for iptables bin check https://github.com/k3s-io/k3s/pull/7315[(#7315)]
 * Update channel server for april 2023 https://github.com/k3s-io/k3s/pull/7327[(#7327)]


### PR DESCRIPTION
Remove Version Gate admonitions that reference K3s releases which are now end-of-life, across the CLI, datastore, installation, networking, and reference docs. Also add a note in the etcd-snapshot docs clarifying that `--etcd-snapshot-retention` sets `--etcd-s3-retention` when the latter is not explicitly configured, and drop the now-redundant "S3 Retention" subsection.

In the dual-stack networking page, the corresponding upstream change left an orphaned `node-ip` code block (a pre-1.27 workaround) with a dangling admonition delimiter; since that workaround targets EOL releases, it is dropped here for a clean render.

Ported from k3s-io/docs: https://github.com/k3s-io/docs/pull/581