### PR TITLE
[sync k3s-docs] Add docs about the new helm-controller flag

### DIFF
--- a/docs/latest/modules/en/pages/add-ons/helm.adoc
+++ b/docs/latest/modules/en/pages/add-ons/helm.adoc
@@ -1,6 +1,6 @@
 = Helm
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-01-05
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 :page-aliases: helm.adoc
 
@@ -13,6 +13,26 @@ K3s includes a https://github.com/k3s-io/helm-controller/[Helm Controller] that 
 == Using the Helm Controller
 
 The https://github.com/k3s-io/helm-controller#helm-controller[HelmChart Custom Resource] captures most of the options you would normally pass to the `helm` command-line tool.
+
+K3s also supports passing arguments directly to the `helm-controller` process with `helm-controller-arg`.
+This is useful when you want to tune controller behavior globally.
+
+For example, to customize the CPU and memory resources allocated to Helm job pods:
+
+[source,yaml]
+----
+# /etc/rancher/k3s/config.yaml
+helm-controller-arg:
+  - 'job-resources={"requests": {"cpu": "0.2", "memory": "64M"}, "limits": {"cpu": "1", "memory": "256M"}}'
+----
+
+You can specify `helm-controller-arg` multiple times in CLI form, or as a YAML list in the configuration file.
+
+[IMPORTANT]
+.Version Gate
+====
+The `helm-controller-arg` flag is available since the K3s July 2026 releases: v1.36.3+k3s1, v1.35.7+k3s1, v1.34.10+k3s1, v1.33.13+k3s2
+====
 
 === HelmChart Field Definitions
 

--- a/docs/latest/modules/en/pages/cli/server.adoc
+++ b/docs/latest/modules/en/pages/cli/server.adoc
@@ -1,7 +1,7 @@
 = k3s server
 :revdate: 2026-03-31
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-05-26
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 In this section, you'll learn how to configure the K3s server.
@@ -519,7 +519,7 @@ OPTIONS:
    --write-kubeconfig value, -o value         (client) Write kubeconfig for admin client to this file [$K3S_KUBECONFIG_OUTPUT]
    --write-kubeconfig-mode value              (client) Write kubeconfig with this mode [$K3S_KUBECONFIG_MODE]
    --write-kubeconfig-group value             (client) Write kubeconfig with this group [$K3S_KUBECONFIG_GROUP]
-   --helm-job-image value                     (helm) Default image to use for helm jobs
+   --helm-controller-arg value                (helm) Customized configuration for helm-controller process
    --token value, -t value                    (cluster) Shared secret used to join a server or agent to a cluster [$K3S_TOKEN]
    --token-file value                         (cluster) File containing the token [$K3S_TOKEN_FILE]
    --agent-token value                        (cluster) Shared secret used to join agents to the cluster, but not servers [$K3S_AGENT_TOKEN]


### PR DESCRIPTION
Document the new `helm-controller-arg` server flag, which passes arguments directly to the helm-controller process (e.g. tuning the CPU/memory resources of Helm job pods via `job-resources`). Also update the `k3s server` CLI reference: the `--helm-job-image` entry is replaced by `--helm-controller-arg`.

Ported from k3s-io/docs: https://github.com/k3s-io/docs/pull/583